### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/assets/provisioning-sam/template.yaml
+++ b/assets/provisioning-sam/template.yaml
@@ -38,7 +38,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: handler.getStackAvailability
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
       Events:
@@ -52,7 +52,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: handler.provisionThing
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
       Environment:
@@ -76,7 +76,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: cameraHandler.status
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
       Events:
@@ -90,7 +90,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: cameraHandler.pair
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
       Events:
@@ -104,7 +104,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: cameraHandler.shadow
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
       Events:
@@ -120,7 +120,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: cfcustomresources/roleAlias.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
   RoleAliasCustomResource:
@@ -137,7 +137,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: cfcustomresources/provisioningKey.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
   ProvisioningKeyCustomResource:
@@ -175,7 +175,7 @@ Resources:
     Properties:
       CodeUri: src/
       Handler: handler.monitoring
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Role:
         Fn::GetAtt: ProvisioningLambdaRole.Arn
   MonitoringLambdaInvokePermission:


### PR DESCRIPTION
CloudFormation templates in quickstart-onica-connected-camera have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.